### PR TITLE
Fix downloadJdk config for generic builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,11 @@ task downloadJdk( type: Download ) {
     overwrite false
     onlyIfModified true
 
-    src getJdkDownloadUrl()
-    dest new File( downloadJdkDir, getJdkPackageFile() )
+    if ( !isGenericBuild() )
+    {
+        src getJdkDownloadUrl()
+        dest new File( downloadJdkDir, getJdkPackageFile() )
+    }
 
     doFirst {
         mkdir downloadJdkDir


### PR DESCRIPTION
Prevented configuration of the JDK src for generic builds, since task configuration is done before the `onlyIf` checks, which was leading to errors in JDK URL fetching.