### PR TITLE
Released v7.16.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 #
 
 # XP version:
-version=7.16.0-SNAPSHOT
+version=7.16.0
 
 systemProp.org.gradle.internal.http.connectionTimeout=120000
 systemProp.org.gradle.internal.http.socketTimeout=120000


### PR DESCRIPTION
The system apps have been built with the v7.16.0 tag, but the tests can't run until the distro is ready for download.