### PR TITLE
Remove arm64 JNA exclusion workaround

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,10 +154,6 @@ distributions {
                         permissions { unix '0755' }
                     }
                 }
-                if ( isArm64() )
-                {
-                    exclude { (it.file.name == 'jna-4.1.0.jar') }
-                }
             }
             into( "system/$appLevel" ) {
                 from configurations.app

--- a/jdk.gradle
+++ b/jdk.gradle
@@ -125,10 +125,6 @@ def withJava()
     return !isGenericBuild()
 }
 
-def isArm64() {
-    return [ 'linux-arm64', 'mac-arm64'].contains( getTargetOsName() )
-}
-
 def getTargetOsName()
 {
     return project.findProperty( 'os' ) ?: 'generic'
@@ -159,5 +155,4 @@ ext {
     withDistTar = this.&withDistTar
     withDistZip = this.&withDistZip
     withJava = this.&withJava
-    isArm64 = this.&isArm64
 }


### PR DESCRIPTION
Ref enonic/xp#12134 (XP PR enonic/xp#12135).

XP bumps JNA `4.1.0` → `5.19.0`, which ships native dispatch libraries for `darwin-aarch64` / `linux-aarch64`. JNA 4.1.0 had no arm64 native, so this distro excluded `jna-4.1.0.jar` from arm64 builds. With 5.19.0 that exclusion is obsolete.

Removes:
- the `if ( isArm64() ) { exclude { … 'jna-4.1.0.jar' } }` block in `build.gradle` (it would no longer match the renamed `jna-5.19.0.jar` anyway);
- the now-unused `isArm64()` helper and its `ext` export in `jdk.gradle` (JDK arch selection uses `getTargetOsName()` directly and is unaffected).

⚠️ **Merge ordering:** only merge once the consumed `8.1.0-SNAPSHOT` runtime ships JNA 5.19.0 (i.e. after enonic/xp#12135 is merged and the runtime is republished). Merging earlier would re-include the broken `jna-4.1.0.jar` in arm64 distributions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)