### PR TITLE
Update GraalVM to 25.2.4 #338

### DIFF
--- a/jdk.gradle
+++ b/jdk.gradle
@@ -13,7 +13,9 @@ enum TargetOS {
 
     String vmDownloadPlatform
 
-    String jdkVersion = '25.0.3'
+    String graalTrain = '25i2'
+
+    String jdkVersion = '25.0.4'
 
     TargetOS( String vmDownloadPlatform, String downloadExt, String archiveJavaHome )
     {
@@ -24,7 +26,7 @@ enum TargetOS {
 
     String toJdkPackageName()
     {
-        return "graalvm-jdk-${jdkVersion}_${vmDownloadPlatform}_bin"
+        return "graalvm-jdk-${graalTrain}-${jdkVersion}_${vmDownloadPlatform}_bin"
     }
 
     String toJdkPackageFile()
@@ -37,7 +39,7 @@ enum TargetOS {
     String toDownloadString()
     {
         def jdkPackageFile = toJdkPackageFile()
-        return "https://download.oracle.com/graalvm/25/archive/${jdkPackageFile}"
+        return "https://gds.oracle.com/download/graal/${graalTrain}/archive/${jdkPackageFile}"
     }
 
     static from( String targetPlatform )


### PR DESCRIPTION
Move to the GraalVM feature-release train: graal 25.2.4 (25i2) on JDK 25.0.4, downloaded from gds.oracle.com instead of download.oracle.com. Note: macos-x64 is discontinued in this train (target was already unreachable via the os mapping). Ref #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)